### PR TITLE
Update spe-da-adv.md

### DIFF
--- a/docs/embedded/development/declarative-agent/spe-da-adv.md
+++ b/docs/embedded/development/declarative-agent/spe-da-adv.md
@@ -52,7 +52,7 @@ Connect-SPOService "https://<domain>-admin.sharepoint.com"
 # Login with your admin account.
 ...
 
-Set-SPOApplication -OwningApplicationId 423poi45 -CopilotEmbeddedChatHosts "http://localhost:3000 https://contoso.sharepoint.com https://fabrikam.com" 
+Set-SPOApplication -OwningApplicationId XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX -CopilotEmbeddedChatHosts "http://localhost:3000 https://contoso.sharepoint.com https://fabrikam.com" 
 
 # This will set the container type configuration “CopilotEmbeddedChatHosts” accordingly. 
 ...


### PR DESCRIPTION
The -OwningApplicationId is a UUID format, and in the example it was just 8 random characters, which wasn't clear.

## Category

- [X] Content fix
- [ ] New article

## What's in this Pull Request?

Adding clarity to the CSP section for the owning application ID


